### PR TITLE
Add epub cache

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -167,7 +167,10 @@ pub fn load_library(state: &mut Pend) {
       state.shelves.push(PathGroup::new("Books"));
     }
 
-    // Add file to library if not already added
+    let mut epub = EpubDoc::new(&file_path).unwrap();
+    let title = epub.mdata("title").unwrap();
+
+    // Add file path to library if not already added
     if !state
       .shelves
       .iter()
@@ -175,13 +178,14 @@ pub fn load_library(state: &mut Pend) {
       .any(|x| x == file_path)
     {
       state.shelves[0].paths.push(file_path.clone());
+      state
+        .epub_cache
+        .insert(file_path.clone(), EpubDoc::new(&file_path).unwrap());
     }
-    // Same thing for the book cover
-    let mut doc = EpubDoc::new(&file_path).unwrap();
-    let title = doc.mdata("title").unwrap();
 
-    if doc.get_cover().is_ok() {
-      let cover = doc.get_cover().unwrap();
+    // Add book cover to cache of book covers
+    if epub.get_cover().is_ok() {
+      let cover = epub.get_cover().unwrap();
       let cover = RetainedImage::from_image_bytes(&title, &cover).unwrap();
 
       state.book_covers.insert(title, cover);

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,11 @@ fn main() {
   let native_options = NativeOptions {
     min_window_size: Some(vec2(960.0, 540.0)),
     icon_data: Some(IconData {
-      rgba: image::load_from_memory(include_bytes!("../compiletime_resources/pend.png")).unwrap().into_bytes(),
+      rgba: image::load_from_memory(include_bytes!(
+        "../compiletime_resources/pend.png"
+      ))
+      .unwrap()
+      .into_bytes(),
       width: 64,
       height: 64,
     }),

--- a/src/panels/config.rs
+++ b/src/panels/config.rs
@@ -23,7 +23,6 @@ pub fn ui(state: &mut crate::app::Pend, ui: &mut egui::Ui) {
     if ui.button("Force Clear Library").clicked() {
       state.shelves.clear();
       state.book_covers.clear();
-      state.selected_book = None;
       state.selected_book_path = None;
     }
 

--- a/src/panels/reader.rs
+++ b/src/panels/reader.rs
@@ -8,222 +8,227 @@ use crate::{
 
 pub fn right_panel_reader_ui(state: &mut Pend, ui: &mut egui::Ui) {
   // Displays page(s) of the book
-  if let Some(book) = &mut state.selected_book {
-    // If a book is loaded there will be a path, only panics if
-    // unexpected unloading of that path occurs
-    let selected_book_path = state.selected_book_path.as_ref().unwrap();
+  if let Some(selected_book_path) = &state.selected_book_path {
+    if let Some(book) = &mut state.epub_cache.get_mut(selected_book_path) {
+      // If a book is loaded there will be a path, only panics if
+      // unexpected unloading of that path occurs
+      let selected_book_path = state.selected_book_path.as_ref().unwrap();
 
-    let book_userdata =
-      state.book_userdata.get_mut(selected_book_path).unwrap();
+      let book_userdata =
+        state.book_userdata.get_mut(selected_book_path).unwrap();
 
-    if let Some(target) = &state.goto_target {
-      book_userdata.chapter = target.chapter as usize;
-    }
-
-    // Key-based page navigation
-    if ui.ctx().input().key_pressed(egui::Key::ArrowLeft)
-      && book.get_current_page() > 1
-    {
-      book_userdata.chapter -= 1;
-    }
-    if ui.ctx().input().key_pressed(egui::Key::ArrowRight)
-      && book.get_current_page() < book.get_num_pages() - 1
-    {
-      book_userdata.chapter += 1;
-    }
-
-    ui.horizontal(|ui| {
-      if state.ui_state.reader_focus_mode {
-        // Collapse focus
-        if ui
-          .add(egui::Button::new(RichText::new("Unfocus")))
-          .clicked()
-        {
-          state.ui_state.reader_focus_mode = false;
-        }
-      } else {
-        // Expand focus
-        if ui.add(egui::Button::new(RichText::new("Focus"))).clicked() {
-          state.ui_state.reader_focus_mode = true;
-        }
-
-        ui.separator();
-
-        ui.label(format!("Chapter: {}", &book_userdata.chapter));
-
-        ui.spacing_mut().slider_width = ui.available_width();
-        ui.add(
-          egui::Slider::new(
-            &mut book_userdata.chapter,
-            1..=book.get_num_pages() - 1,
-          )
-          .show_value(false),
-        );
+      if let Some(target) = &state.goto_target {
+        book_userdata.chapter = target.chapter as usize;
       }
-    });
 
-    // Apply page / chapter change of needed
-    if book.get_current_page() != book_userdata.chapter {
-      book.set_current_page(book_userdata.chapter).unwrap();
-      state.goto_target = Some(Note::new(book_userdata.chapter as u16, 0));
-    }
+      // Key-based page navigation
+      if ui.ctx().input().key_pressed(egui::Key::ArrowLeft)
+        && book.get_current_page() > 1
+      {
+        book_userdata.chapter -= 1;
+      }
+      if ui.ctx().input().key_pressed(egui::Key::ArrowRight)
+        && book.get_current_page() < book.get_num_pages() - 1
+      {
+        book_userdata.chapter += 1;
+      }
 
-    ui.separator();
-
-    // Display of page (CHAPTER) contents
-    ScrollArea::new([false, true])
-      .always_show_scroll(false)
-      .auto_shrink([false, true])
-      .show(ui, |ui| {
-        if state.ui_state.display_raw_text {
-          ui.label(&book.get_current_str().unwrap());
+      ui.horizontal(|ui| {
+        if state.ui_state.reader_focus_mode {
+          // Collapse focus
+          if ui
+            .add(egui::Button::new(RichText::new("Unfocus")))
+            .clicked()
+          {
+            state.ui_state.reader_focus_mode = false;
+          }
         } else {
-          let style = &state.book_style;
-          let theme = &state.theme;
+          // Expand focus
+          if ui.add(egui::Button::new(RichText::new("Focus"))).clicked() {
+            state.ui_state.reader_focus_mode = true;
+          }
 
-          if let Ok(page_data) = book.get_current_str() {
-            let contents =
-              parse_calibre(&page_data, book.get_current_page(), book_userdata);
-            let contents = contents.lines();
+          ui.separator();
 
-            // Background
-            ui.painter()
-              .rect_filled(ui.clip_rect(), 0.0, theme.page_color);
+          ui.label(format!("Chapter: {}", &book_userdata.chapter));
 
-            // Actual "stuff"
-            let font_id =
-              FontId::new(style.font_size, style.font_family.clone());
-            let line_spacing =
-              ui.fonts().row_height(&font_id) * style.line_spacing_multiplier;
+          ui.spacing_mut().slider_width = ui.available_width();
+          ui.add(
+            egui::Slider::new(
+              &mut book_userdata.chapter,
+              1..=book.get_num_pages() - 1,
+            )
+            .show_value(false),
+          );
+        }
+      });
 
-            ui.style_mut().spacing.item_spacing.y = line_spacing;
+      // Apply page / chapter change of needed
+      if book.get_current_page() != book_userdata.chapter {
+        book.set_current_page(book_userdata.chapter).unwrap();
+        state.goto_target = Some(Note::new(book_userdata.chapter as u16, 0));
+      }
 
-            let mut goto_target_response = None;
+      ui.separator();
 
-            for (line_number, line) in contents.into_iter().enumerate() {
-              let line_response = ui.add(
-                Label::new({
-                  // Creates text with normal / default appearence
-                  // This is how normal body text looks
-                  let mut text = RichText::new(line)
-                    .color(theme.text_color)
-                    .background_color(
-                      book_userdata
-                        .highlights
-                        .get(&(book_userdata.chapter, line_number))
-                        .map_or(Color32::TRANSPARENT, |color| *color),
-                    )
-                    .font(font_id.clone());
+      // Display of page (CHAPTER) contents
+      ScrollArea::new([false, true])
+        .always_show_scroll(false)
+        .auto_shrink([false, true])
+        .show(ui, |ui| {
+          if state.ui_state.display_raw_text {
+            ui.label(&book.get_current_str().unwrap());
+          } else {
+            let style = &state.book_style;
+            let theme = &state.theme;
 
-                  // Applies special formatting (heading, bold, etc.)
-                  if let Some(info) = book_userdata
-                    .formatting_info
-                    .get(&(book_userdata.chapter, line_number))
-                  {
-                    match info {
-                      FormattingInfo::Title => {
-                        text = text.size(font_id.size * 1.75);
+            if let Ok(page_data) = book.get_current_str() {
+              let contents = parse_calibre(
+                &page_data,
+                book.get_current_page(),
+                book_userdata,
+              );
+              let contents = contents.lines();
+
+              // Background
+              ui.painter()
+                .rect_filled(ui.clip_rect(), 0.0, theme.page_color);
+
+              // Actual "stuff"
+              let font_id =
+                FontId::new(style.font_size, style.font_family.clone());
+              let line_spacing =
+                ui.fonts().row_height(&font_id) * style.line_spacing_multiplier;
+
+              ui.style_mut().spacing.item_spacing.y = line_spacing;
+
+              let mut goto_target_response = None;
+
+              for (line_number, line) in contents.into_iter().enumerate() {
+                let line_response = ui.add(
+                  Label::new({
+                    // Creates text with normal / default appearence
+                    // This is how normal body text looks
+                    let mut text = RichText::new(line)
+                      .color(theme.text_color)
+                      .background_color(
+                        book_userdata
+                          .highlights
+                          .get(&(book_userdata.chapter, line_number))
+                          .map_or(Color32::TRANSPARENT, |color| *color),
+                      )
+                      .font(font_id.clone());
+
+                    // Applies special formatting (heading, bold, etc.)
+                    if let Some(info) = book_userdata
+                      .formatting_info
+                      .get(&(book_userdata.chapter, line_number))
+                    {
+                      match info {
+                        FormattingInfo::Title => {
+                          text = text.size(font_id.size * 1.75);
+                        }
+                        FormattingInfo::Heading => {
+                          text = text.size(font_id.size * 1.5);
+                        }
+                        FormattingInfo::Heading2 => {
+                          text = text.size(font_id.size * 1.25);
+                        }
+                        FormattingInfo::Bold => text = text.strong(),
+                        FormattingInfo::Italic => text = text.italics(),
                       }
-                      FormattingInfo::Heading => {
-                        text = text.size(font_id.size * 1.5);
-                      }
-                      FormattingInfo::Heading2 => {
-                        text = text.size(font_id.size * 1.25);
-                      }
-                      FormattingInfo::Bold => text = text.strong(),
-                      FormattingInfo::Italic => text = text.italics(),
                     }
+
+                    text
+                  })
+                  .sense(Sense::click()),
+                );
+
+                if let Some(target) = &state.goto_target {
+                  if line_number == target.line as usize {
+                    goto_target_response = Some(line_response.clone());
+                  }
+                }
+
+                // Context menu
+                line_response.context_menu(|ui| {
+                  ui.horizontal(|ui| {
+                    for (index, color) in [
+                      state.theme.highlight_color,
+                      Color32::from_rgb(255, 150, 138),
+                      Color32::from_rgb(255, 209, 138),
+                      Color32::from_rgb(138, 255, 150),
+                      Color32::from_rgb(150, 138, 255),
+                    ]
+                    .iter()
+                    .enumerate()
+                    {
+                      // Separator placed after the first option to indicate
+                      // the user's custom selected highlight color
+                      if index == 1 {
+                        ui.separator();
+                        ui.add_space(6.0);
+                      }
+
+                      // Button & logic
+                      if ui
+                        .button(
+                          RichText::new("\u{25CF}").color(*color).size(32.0),
+                        )
+                        .clicked()
+                      {
+                        let coord = (book_userdata.chapter, line_number);
+
+                        if let Some(existing_color) =
+                          book_userdata.highlights.get_mut(&coord)
+                        {
+                          if *existing_color == *color {
+                            book_userdata.highlights.remove(&coord);
+                          } else {
+                            *existing_color = *color;
+                          };
+                        } else {
+                          book_userdata.highlights.insert(coord, *color);
+                        }
+
+                        ui.close_menu();
+                      }
+                    }
+                  });
+
+                  if ui.button("Copy").clicked() {
+                    ui.output().copied_text = line.to_string();
+                    ui.close_menu();
                   }
 
-                  text
-                })
-                .sense(Sense::click()),
-              );
+                  if ui.button("Add Note").clicked() {
+                    let note = Note::new(
+                      book.get_current_page() as u16,
+                      line_number as u16,
+                    );
 
-              if let Some(target) = &state.goto_target {
-                if line_number == target.line as usize {
-                  goto_target_response = Some(line_response.clone());
-                }
-              }
-
-              // Context menu
-              line_response.context_menu(|ui| {
-                ui.horizontal(|ui| {
-                  for (index, color) in [
-                    state.theme.highlight_color,
-                    Color32::from_rgb(255, 150, 138),
-                    Color32::from_rgb(255, 209, 138),
-                    Color32::from_rgb(138, 255, 150),
-                    Color32::from_rgb(150, 138, 255),
-                  ]
-                  .iter()
-                  .enumerate()
-                  {
-                    // Separator placed after the first option to indicate
-                    // the user's custom selected highlight color
-                    if index == 1 {
-                      ui.separator();
-                      ui.add_space(6.0);
-                    }
-
-                    // Button & logic
-                    if ui
-                      .button(
-                        RichText::new("\u{25CF}").color(*color).size(32.0),
-                      )
-                      .clicked()
-                    {
-                      let coord = (book_userdata.chapter, line_number);
-
-                      if let Some(existing_color) =
-                        book_userdata.highlights.get_mut(&coord)
-                      {
-                        if *existing_color == *color {
-                          book_userdata.highlights.remove(&coord);
-                        } else {
-                          *existing_color = *color;
-                        };
-                      } else {
-                        book_userdata.highlights.insert(coord, *color);
-                      }
+                    // Adds the note if one is not already in place for the specified chapter / line combo
+                    if !book_userdata.notes.contains(&note) {
+                      book_userdata.notes.push(note);
+                      state.ui_state.left_panel_state = PanelState::Notes;
 
                       ui.close_menu();
                     }
                   }
                 });
+              }
 
-                if ui.button("Copy").clicked() {
-                  ui.output().copied_text = line.to_string();
-                  ui.close_menu();
-                }
-
-                if ui.button("Add Note").clicked() {
-                  let note = Note::new(
-                    book.get_current_page() as u16,
-                    line_number as u16,
-                  );
-
-                  // Adds the note if one is not already in place for the specified chapter / line combo
-                  if !book_userdata.notes.contains(&note) {
-                    book_userdata.notes.push(note);
-                    state.ui_state.left_panel_state = PanelState::Notes;
-
-                    ui.close_menu();
-                  }
-                }
-              });
+              if let Some(response) = goto_target_response {
+                response.scroll_to_me(Some(egui::Align::TOP));
+                state.goto_target = None;
+              }
+            } else {
+              ui.label("Unable to load page data");
             }
-
-            if let Some(response) = goto_target_response {
-              response.scroll_to_me(Some(egui::Align::TOP));
-              state.goto_target = None;
-            }
-          } else {
-            ui.label("Unable to load page data");
           }
-        }
-      });
-  } else {
-    ui.label("No book loaded");
+        });
+    } else {
+      ui.label("No book loaded");
+    }
   }
 }

--- a/src/panels/shelf.rs
+++ b/src/panels/shelf.rs
@@ -1,5 +1,4 @@
 use egui::{vec2, Align2, RichText, TextEdit};
-use epub::doc::EpubDoc;
 
 use crate::backend::{load_library, PathGroup, RenameState};
 
@@ -82,11 +81,11 @@ pub fn ui(state: &mut crate::Pend, ui: &mut egui::Ui) {
         // Loop over all paths within a shelf and show the books
         for (path_index, path) in path_group.paths.iter().enumerate() {
           // Ensure the path leads to a valid epub document
-          if let Ok(doc) = EpubDoc::new(path) {
-            let title = doc
+          if let Some(epub) = state.epub_cache.get(path) {
+            let title = epub
               .mdata("title")
               .unwrap_or_else(|| "<Missing Title>".to_string());
-            let author = doc
+            let author = epub
               .mdata("creator")
               .unwrap_or_else(|| "<Missing Title>".to_string());
 
@@ -176,7 +175,6 @@ pub fn ui(state: &mut crate::Pend, ui: &mut egui::Ui) {
                 } else {
                   // Select book on click
                   if cover_response.clicked() {
-                    state.selected_book = Some(EpubDoc::new(path).unwrap());
                     state.selected_book_path = Some(path.clone());
                   }
                 }

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -170,7 +170,7 @@ pub fn main(ctx: &Context, state: &mut Pend) {
   	}
 
 		// Panels
-		if !state.ui_state.reader_focus_mode || state.selected_book.is_none() {
+		if !state.ui_state.reader_focus_mode || state.selected_book_path.is_none() {
 			egui::SidePanel::left("Left Panel")
 				.resizable(true)
 				.width_range(area_width / 3.0..=area_width / 1.5)
@@ -184,7 +184,7 @@ pub fn main(ctx: &Context, state: &mut Pend) {
 
 						// Vertical UI for the sole purpose of containing the enable
 						ui.vertical(|ui| {
-							ui.set_enabled(state.selected_book.is_some());
+							ui.set_enabled(state.selected_book_path.is_some());
 							ui.selectable_value(
 								&mut state.ui_state.left_panel_state,
 								PanelState::Notes,


### PR DESCRIPTION
Implements a cache of epubs searchable by path instead of creating a new epub for every (visible) book every frame. Should increase performance by quite a bit and reduce memory i/o.
Commit is actually pretty small but I had to stick something in an `if let` so it appears bigger.
I really have no idea why I did it like that.